### PR TITLE
Implement argument parser with hidden arguments

### DIFF
--- a/fuzz-sat
+++ b/fuzz-sat
@@ -3,26 +3,66 @@
 import sys
 import subprocess
 import os
+import argparse
 
 # Fayeth/
 exec_dir = os.path.abspath(os.path.dirname(os.path.abspath(__file__)))
 
-# Get arguments
-args = sys.argv[1:]
+# Argument parsing
 
-# Check arguments length
-if len(args) < 3:
-	print("Usage: ./fuzz-sat <sut-executable> <input-files-dir> <ub/func> [seed]")
-	print("Example: ./fuzz-sat res/banosat/sat . ub 645")
-	sys.exit(1)
+def usage_msg():
+    return '''Help: ./fuzz-sat -h
+Example: ./fuzz-sat res/banosat/sat . ub 645 --nothreading --limit 10
+'''
+
+parser = argparse.ArgumentParser(usage=usage_msg())
+
+parser.add_argument('sutexecutable',
+                    help='Path to the sat executable under test'
+                    )
+
+parser.add_argument('inputfilesdir',
+                    help='Path to directory containing seed cnf files'
+                    )
+
+parser.add_argument('ubfunc',
+                    help='Operation mode. [ub/func]',
+                    choices=['ub', 'func']
+                    )
+
+parser.add_argument('seed',
+                    help='Random number generation seed',
+                    nargs='?',
+                    default=None
+                    )
+
+parser.add_argument('--nothreading',
+                    help='Disable multithreading',
+                    action='store_true',
+                    default=False
+                    )
+
+parser.add_argument('--nogc',
+                    help='Disable garbage collection of temporary generated file in /tmp',
+                    action='store_true',
+                    default=False
+                    )
+
+parser.add_argument('--limit',
+                    help='Set a limit to the number of iterations. If not set, the fuzzer will run infinitely',
+                    type=int,
+                    default=0
+                    )
+
+args = parser.parse_args()
 
 # SUT path
-sut_path = os.path.abspath(args[0])
+sut_path = os.path.abspath(args.sutexecutable)
 sut_path = os.path.abspath(os.path.dirname(sut_path))
 os.chdir(sut_path)
 	
 # Input directory
-input_dir = os.path.abspath(args[1])
+input_dir = os.path.abspath(args.inputfilesdir)
 
 # Output directory
 output_dir = os.path.abspath(os.path.join(exec_dir, "fuzzed-tests"))
@@ -32,16 +72,16 @@ subprocess.call(["rm", "-rf", output_dir], shell=False)
 subprocess.call(["mkdir", output_dir], shell=False)
 
 # Mode
-mode = args[2]
+mode = args.ubfunc
 
 # Seed
-if len(args) >= 4:
-	seed = args[3]
-else:
-	seed = None
+seed = args.seed
 
 # Setup environment variables
 os.environ["LIBC_FATAL_STDERR_"] = "1"
+os.environ["FAYETH_NOTHREADING"] = "1" if args.nothreading else "0"
+os.environ["FAYETH_NOGC"]        = "1" if args.nogc else "0"
+os.environ["FAYETH_LIMIT"]       = str(args.limit)
 
 # Construct command
 cmd = []

--- a/src/fayeth/engine/ub/UbEngine.java
+++ b/src/fayeth/engine/ub/UbEngine.java
@@ -30,7 +30,7 @@ public class UbEngine implements Engine {
             throw new RuntimeException("No configuration for UbEngine. Please call setConfiguration first");
         }
         
-        if (arguments.isMultithreadingAllowed()) {
+        if (arguments.isThreadingEnabled()) {
             // TODO add multithreaded supportc
             throw new RuntimeException("Multithreading is not supported yet. Please provide a fixed seed for reproducibility");
         } else {
@@ -40,7 +40,8 @@ public class UbEngine implements Engine {
 
     private void runSequential() {
         try {
-            while (true) {
+            int limit = arguments.getLimit();
+            for (long i = 0; limit == 0 || i < limit; i++) {
                 for(Strategy strategy : strategies) {
                     TestableInput input = strategy.generateNextInput();
                     UbTask task = new UbTask(input, arguments, strategy);

--- a/src/fayeth/engine/ub/UbTask.java
+++ b/src/fayeth/engine/ub/UbTask.java
@@ -57,7 +57,9 @@ public class UbTask implements Task {
         sp.waitFor();
         
         // Cleanup
-        tempFile.delete();
+        if (!arguments.isGcDisabled()) {
+            tempFile.delete();
+        }
         
         return outcome;
     }

--- a/src/fayeth/program/state/Args.java
+++ b/src/fayeth/program/state/Args.java
@@ -32,12 +32,20 @@ public class Args {
         return seed;
     }
 
-    public boolean isMultithreadingAllowed() {
-        return seed == null;
-    }
-
     public Mode getMode() {
         return mode;
+    }
+    
+    public boolean isThreadingEnabled() {
+        return !"1".equals(System.getenv("FAYETH_NOTHREADING"));
+    }
+    
+    public boolean isGcDisabled() {
+        return "1".equals(System.getenv("FAYETH_NOGC"));
+    }
+    
+    public int getLimit() {
+        return Integer.parseInt(System.getenv("FAYETH_LIMIT"));
     }
 
     @Override


### PR DESCRIPTION
There are now new command line arguments supported:

```
gj@gj-ub ~/git/Fayeth (hidden_argparse) $ ./fuzz-sat -h
usage: Help: ./fuzz-sat -h
Example: ./fuzz-sat res/banosat/sat . ub 645 --nothreading --limit 10

positional arguments:
  sutexecutable  Path to the sat executable under test
  inputfilesdir  Path to directory containing seed cnf files
  {ub,func}      Operation mode. [ub/func]
  seed           Random number generation seed

optional arguments:
  -h, --help     show this help message and exit
  --nothreading  Disable multithreading
  --nogc         Disable garbage collection of temporary generated file in
                 /tmp
  --limit LIMIT  Set a limit to the number of iterations. If not set, the
                 fuzzer will run infinitely
```

New features:

* explicitly enable/disable multithreading. For now our fuzzer only works with `--nothreading`
* passing `--nogc` will not garbage collect the temporary files in /tmp
* passing `--limit X` will limit the fuzzer to only X runs instead of running infinitely

The base syntax as specified still works